### PR TITLE
feature/async

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "DiskCache",
-        "repositoryURL": "git@github.com:Mobelux/DiskCache.git",
+        "repositoryURL": "https://github.com/Mobelux/DiskCache.git",
         "state": {
           "branch": null,
           "revision": "dc9d51b67abefb41669cee38534cf86ab92ea610",
@@ -12,11 +12,11 @@
       },
       {
         "package": "swift-crypto",
-        "repositoryURL": "git@github.com:apple/swift-crypto.git",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
-          "version": "1.0.1"
+          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
+          "version": "1.1.6"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:Mobelux/DiskCache.git",
         "state": {
           "branch": null,
-          "revision": "678d6f1e283836535488fd9f1776f40719e2e137",
-          "version": "1.1.2"
+          "revision": "dc9d51b67abefb41669cee38534cf86ab92ea610",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com:Mobelux/DiskCache.git", from: "2.0.0"),
-        .package(url: "git@github.com:apple/swift-crypto.git", from: "1.0.0")
+        .package(url: "https://github.com/Mobelux/DiskCache.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,15 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "codable-cache",
-    platforms: [.iOS(.v13),
-                .macOS(.v10_15)
+    platforms: [
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -16,16 +19,19 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(url: "git@github.com:Mobelux/DiskCache.git", from: "1.0.0"),
-         .package(url: "git@github.com:apple/swift-crypto.git", from: "1.0.0")
+        .package(url: "git@github.com:Mobelux/DiskCache.git", from: "2.0.0"),
+        .package(url: "git@github.com:apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "CodableCache",
-            dependencies: ["DiskCache",
-                           .product(name: "Crypto", package: "swift-crypto")
+            dependencies: [
+                "DiskCache",
+                .product(
+                    name: "Crypto",
+                    package: "swift-crypto")
             ]),
         .testTarget(
             name: "CodableCacheTests",

--- a/Sources/CodableCache/CodableCache.swift
+++ b/Sources/CodableCache/CodableCache.swift
@@ -25,23 +25,34 @@ public final class CodableCache {
 
     private let cache: Cache
 
+    /// Initilize and instance of `CodableCache`
+    /// - Parameter cache: A type conforming to the `Cache` protocol.
     public init(_ cache: Cache) {
         self.cache = cache
     }
 
+    /// Asynchronously caches the given object
+    /// - Parameter object: The object which should be cached. It must conform to `Codable`.
+    /// - Parameter key: A unique key used to identify the cached object.
+    /// - Parameter ttl: Defines the amount of time the cached object is valid.
     public func cache<T: Codable>(object: T, key: Keyable, ttl: TTL = TTL.default) async throws {
         let wrapper = CacheWrapper(ttl: ttl, created: Date(), object: object)
         try await cache.cache(try encoder.encode(wrapper), key: key.rawValue)
     }
 
+    /// Deletes the cached object associated with the given key
+    /// - Parameter key: A unique key used to identify the cached object
     public func delete(objectWith key: Keyable) async throws {
         try await cache.delete(key.rawValue)
     }
 
+    /// Deletes all cached objects
     public func deleteAll() async throws {
         try await cache.deleteAll()
     }
 
+    /// Asynchronously gets an object from the cache.
+    /// - Returns: An instance of the previously cached object. If the `ttl` has expired or if nothing has been cached for `key`, returns nil
     public func object<T: Codable>(key: Keyable) async -> T? {
         do {
             let data = try await self.cache.data(key.rawValue)

--- a/Sources/CodableCache/CodableCache.swift
+++ b/Sources/CodableCache/CodableCache.swift
@@ -27,7 +27,7 @@ public final class CodableCache {
 
     private let cache: Cache
 
-    /// Initilize and instance of `CodableCache`
+    /// Initilize an instance of `CodableCache`
     /// - Parameter cache: A type conforming to the `Cache` protocol.
     public init(_ cache: Cache) {
         self.cache = cache

--- a/Sources/CodableCache/CodableCache.swift
+++ b/Sources/CodableCache/CodableCache.swift
@@ -9,14 +9,6 @@ import DiskCache
 import Foundation
 
 public final class CodableCache {
-    private lazy var cache: DiskCache = {
-        do {
-            return try DiskCache(storageType: storageType)
-        } catch {
-            fatalError("Creating cache instance failed with error:\n\(error)")
-        }
-    }()
-
     private lazy var encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -31,10 +23,10 @@ public final class CodableCache {
         return decoder
     }()
 
-    public private(set) var storageType: StorageType
+    private let cache: Cache
 
-    public init(_ storageType: StorageType = .temporary(.custom("codable-cache"))) {
-        self.storageType = storageType
+    public init(_ cache: Cache) {
+        self.cache = cache
     }
 
     public func cache<T: Codable>(object: T, key: Keyable, ttl: TTL = TTL.default) async throws {

--- a/Sources/CodableCache/CodableCaching.swift
+++ b/Sources/CodableCache/CodableCaching.swift
@@ -21,16 +21,18 @@ public final class CodableCaching<Value: Codable> {
     private let cache: () throws -> Cache
     private let key: Keyable
     private let ttl: TTL
-    private var value: Value?
 
+    public var wrappedValue: Value?
     public var projectedValue: CodableCaching<Value> { self }
 
+    /// Asynchronously gets the value from the cache. If the `ttl` has expired or if nothing has been cached for `key`, returns nil
     public func get() async -> Value? {
         let cachedValue: Value? = await codableCache.object(key: key)
-        value = cachedValue
+        wrappedValue = cachedValue
         return cachedValue
     }
 
+    /// Asynchronously caches the given value
     public func set(_ value: Value?) async {
         do {
             if value == nil {
@@ -39,7 +41,7 @@ public final class CodableCaching<Value: Codable> {
                 try await codableCache.cache(object: value, key: key, ttl: ttl)
             }
 
-            self.value = value
+            self.wrappedValue = value
         } catch let error as NSError {
             switch error.code {
             case NSFileNoSuchFileError, NSFileReadNoSuchFileError: break
@@ -51,19 +53,19 @@ public final class CodableCaching<Value: Codable> {
         }
     }
 
-    public var wrappedValue: Value? {
-        get { value }
-        set { value = newValue }
-    }
-
+    /// Initializes an instance of `CodableCaching`
+    /// - Parameters:
+    ///   - wrappedValue: A default value
+    ///   - key: A unique key used to identify the cached object.
+    ///   - cache: A function defining a type conforming to `Cache` to use as backing storage.
+    ///   - ttl: Defines the amount of time the cached object is valid.
     public init(wrappedValue: Value? = nil,
                 key: Keyable,
                 cache: @escaping () throws -> Cache = { try DiskCache(storageType: .temporary(.custom("codable-cache"))) },
                 ttl: TTL = .default) {
-        self.value = wrappedValue
+        self.wrappedValue = wrappedValue
         self.key = key
         self.cache = cache
         self.ttl = ttl
     }
 }
-

--- a/Sources/CodableCache/Extensions/String+md5.swift
+++ b/Sources/CodableCache/Extensions/String+md5.swift
@@ -9,6 +9,10 @@ import CryptoKit
 
 extension String {
     var md5: String {
-        Insecure.MD5.hash(data: data(using: .utf8)!).map { String(format:"%02X", $0) }.joined().lowercased()
+        Insecure.MD5
+            .hash(data: data(using: .utf8)!)
+            .map { String(format:"%02X", $0) }
+            .joined()
+            .lowercased()
     }
 }

--- a/Sources/CodableCache/Models/TTL.swift
+++ b/Sources/CodableCache/Models/TTL.swift
@@ -12,46 +12,6 @@ public enum TTL: Codable {
         case second, minute, hour, day, forever
     }
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        if let value = try? container.decode(Int.self, forKey: .second) {
-            self = .second(value)
-            return
-        } else if let value = try? container.decode(Int.self, forKey: .minute) {
-            self = .minute(value)
-            return
-        } else if let value = try? container.decode(Int.self, forKey: .hour) {
-            self = .hour(value)
-            return
-        } else if let value = try? container.decode(Int.self, forKey: .day) {
-            self = .day(value)
-            return
-        } else if (try? container.decode(String.self, forKey: .forever)) != nil {
-            self = .forever
-            return
-        }
-
-        throw NSError(domain: "com.mobelux.codable-cache", code: -100, userInfo: [NSLocalizedDescriptionKey: "\(TTL.self) - Decode failure"])
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        switch self {
-        case .second(let time):
-            try container.encode(time, forKey: .second)
-        case .minute(let time):
-            try container.encode(time, forKey: .minute)
-        case .hour(let time):
-            try container.encode(time, forKey: .hour)
-        case .day(let time):
-            try container.encode(time, forKey: .day)
-        case .forever:
-            try container.encode("", forKey: .forever)
-        }
-    }
-
     case second(Int)
     case minute(Int)
     case hour(Int)

--- a/Tests/CodableCacheTests/CodableCacheTests.swift
+++ b/Tests/CodableCacheTests/CodableCacheTests.swift
@@ -3,8 +3,4 @@ import XCTest
 
 final class CodableCacheTests: XCTestCase {
     func testExample() { }
-
-    static var allTests = [
-        ("testExample", testExample),
-    ]
 }

--- a/Tests/CodableCacheTests/CodableCacheTests.swift
+++ b/Tests/CodableCacheTests/CodableCacheTests.swift
@@ -1,6 +1,130 @@
 import XCTest
 @testable import CodableCache
 
+struct Test: Codable, Equatable {
+    let value: String
+}
+
 final class CodableCacheTests: XCTestCase {
-    func testExample() { }
+    static func wrapper(for test: Test, date: Date) -> CacheWrapper<Test> {
+        CacheWrapper(
+            ttl: .default,
+            created: date,
+            object: test)
+    }
+
+    static let test = Test(value: "test-value")
+    var wrapper: CacheWrapper<Test> {
+        CodableCacheTests.wrapper(for: CodableCacheTests.test, date: CodableCache.makeDate())
+    }
+
+    override func setUp() {
+        let date = Date()
+        CodableCache.makeDate = { date }
+    }
+
+    func testCache() async throws {
+        let data = try CodableCache.encoder.encode(wrapper)
+
+        let mockCache = MockCache(instruction: .data(data))
+        let codableCache = CodableCache(mockCache)
+
+        do {
+            try await codableCache.cache(object: Self.test, key: "test", ttl: .default)
+            XCTAssertEqual(mockCache.callable, .cache)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testThrowingCache() async throws {
+        let testError = "throwing-cache"
+
+        let mockCache = MockCache(instruction: .throw(testError))
+        let codableCache = CodableCache(mockCache)
+
+        do {
+            try await codableCache.cache(object: Self.test, key: "test", ttl: .default)
+            XCTFail("Expected failure")
+        } catch {
+            XCTAssertEqual("\(error)", testError)
+            XCTAssertEqual(mockCache.callable, .cache)
+        }
+    }
+
+    func testData() async throws {
+        let testData = try CodableCache.encoder.encode(wrapper)
+
+        let mockCache = MockCache(instruction: .data(testData))
+        let codableCache = CodableCache(mockCache)
+
+        let data: Test? = await codableCache.object(key: "test")
+        XCTAssertEqual(data, Self.test)
+        XCTAssertEqual(mockCache.callable, .data)
+    }
+
+    func testStaleData() async throws {
+        CodableCache.makeDate = { Date(timeIntervalSinceNow: -Double(TTL.day(2).value)) }
+        let testData = try CodableCache.encoder.encode(wrapper)
+        let testError = "throwing-data"
+
+        let mockCache = MockCache(instruction: .dataThrow(testData, testError))
+        let codableCache = CodableCache(mockCache)
+
+        let data: Test? = await codableCache.object(key: "test")
+        XCTAssertEqual(data, nil)
+        XCTAssertEqual(mockCache.callable, .delete)
+    }
+
+    func testDelete() async throws {
+        let mockCache = MockCache(instruction: .none)
+        let codableCache = CodableCache(mockCache)
+
+        do {
+            try await codableCache.delete(objectWith: "test")
+            XCTAssertEqual(mockCache.callable, .delete)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testThrowingDelete() async throws {
+        let testError = "throwing-delete"
+        let mockCache = MockCache(instruction: .throw(testError))
+        let codableCache = CodableCache(mockCache)
+
+        do {
+            try await codableCache.delete(objectWith: "test")
+            XCTFail("Expected failure")
+        } catch {
+            XCTAssertEqual("\(error)", testError)
+            XCTAssertEqual(mockCache.callable, .delete)
+        }
+    }
+
+    func testDeleteAll() async throws {
+        let mockCache = MockCache(instruction: .none)
+        let codableCache = CodableCache(mockCache)
+
+        do {
+            try await codableCache.deleteAll()
+            XCTAssertEqual(mockCache.callable, .deleteAll)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testThrowingDeleteAll() async throws {
+        let testError = "throwing-delete"
+        let mockCache = MockCache(instruction: .throw(testError))
+        let codableCache = CodableCache(mockCache)
+
+        do {
+            try await codableCache.deleteAll()
+            XCTFail("Expected failure")
+        } catch {
+            XCTAssertEqual("\(error)", testError)
+            XCTAssertEqual(mockCache.callable, .deleteAll)
+        }
+    }
 }

--- a/Tests/CodableCacheTests/CodableCachingTest.swift
+++ b/Tests/CodableCacheTests/CodableCachingTest.swift
@@ -1,0 +1,46 @@
+//
+//  CodableCachingTest.swift
+//  
+//
+//  Created by Jeremy Greenwood on 2/24/22.
+//
+
+import XCTest
+@testable import CodableCache
+
+class CodableCachingTest: XCTestCase {
+    @CodableCaching(
+        key: "test",
+        cache: { MockCache(
+            instruction: .data(
+                try! CodableCache.encoder.encode(CacheWrapper(
+                    ttl: .default,
+                    created: CodableCache.makeDate(),
+                    object: "test-value"))
+            )) },
+        ttl: .default)
+    var testValue: String?
+
+    func testGetValue() async {
+        let value = await $testValue.get()
+        XCTAssertEqual(value, "test-value")
+        XCTAssertEqual(testValue, "test-value")
+    }
+
+    func testSetValue() async {
+        await $testValue.set("test-value")
+        XCTAssertEqual(testValue, "test-value")
+    }
+
+    @CodableCaching(
+        key: "test",
+        cache: { MockCache(
+            instruction: .none) },
+        ttl: .default)
+    var testNilValue: String?
+
+    func testNilValue() async {
+        await $testNilValue.set(nil)
+        XCTAssertEqual(testNilValue, nil)
+    }
+}

--- a/Tests/CodableCacheTests/MockCache.swift
+++ b/Tests/CodableCacheTests/MockCache.swift
@@ -1,0 +1,103 @@
+//
+//  MockCache.swift
+//  
+//
+//  Created by Jeremy Greenwood on 2/23/22.
+//
+
+import DiskCache
+import Foundation
+
+class MockCache: Cache {
+    enum Callable {
+        case cache
+        case data
+        case delete
+        case deleteAll
+        case none
+    }
+
+    enum Instruction {
+        case `throw`(Error)
+        case data(Data)
+        case dataThrow(Data, Error)
+        case none
+    }
+
+    init(instruction: Instruction) {
+        self.instruction = instruction
+    }
+
+    var callable: Callable = .none
+    let instruction: Instruction
+
+    func cache(_ data: Data, key: String) async throws {
+        defer {
+            self.callable = .cache
+        }
+
+        switch instruction {
+        case .throw(let error):
+            throw error
+        case .data(let instructionData):
+            guard instructionData == data else {
+                throw "mismatched data"
+            }
+        case .dataThrow:
+            fatalError("not callable")
+        case .none:
+            fatalError("not callable")
+        }
+    }
+
+    func data(_ key: String) async throws -> Data {
+        defer {
+            self.callable = .data
+        }
+
+        switch instruction {
+        case .throw(let error):
+            throw error
+        case .data(let data):
+            return data
+        case let .dataThrow(data, _):
+            return data
+        case .none:
+            fatalError("not callable")
+        }
+    }
+
+    func delete(_ key: String) async throws {
+        defer {
+            self.callable = .delete
+        }
+
+        switch instruction {
+        case .throw(let error):
+            throw error
+        case .data:
+            fatalError("not callable")
+        case let .dataThrow(_, error):
+            throw error
+        case .none: break
+        }
+    }
+
+    func deleteAll() async throws {
+        defer {
+            self.callable = .deleteAll
+        }
+
+        switch instruction {
+        case .throw(let error):
+            throw error
+        case .data:
+            fatalError("not callable")
+        case .dataThrow:
+            fatalError("not callable")
+        case .none: break
+        }
+    }
+
+    func fileURL(_ filename: String) -> URL { fatalError("not callable") }
+}

--- a/Tests/CodableCacheTests/String+Error.swift
+++ b/Tests/CodableCacheTests/String+Error.swift
@@ -1,0 +1,10 @@
+//
+//  String+Error.swift
+//  
+//
+//  Created by Jeremy Greenwood on 2/23/22.
+//
+
+import Foundation
+
+extension String: Error {}

--- a/Tests/CodableCacheTests/XCTestManifests.swift
+++ b/Tests/CodableCacheTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(codable_cacheTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import codable_cacheTests
-
-var tests = [XCTestCaseEntry]()
-tests += codable_cacheTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
Updates `CodableCache` and `CodableCaching` to support Swift's asynchronous functionality. This will allow large data sizes to be cached w/o having to manually manage queues/threads.

The property wrapper (`CodableCaching`) has a significant change in behavior as it now requires calling the projected value to interact with the underlying cache. For example:

```swift
@CodableCaching(key: "awesome-image") var imageData: Data?

func cacheImageData(_ data: Data) async {
    await $imageData.set(data)
}
```
----
- migrate to async cache access
- clean up existing code
- refactored for dependency injection
- add docs
- remove linux test files
- unit tests
- add prop wrapper testcase
